### PR TITLE
Add fetchOnMount prop

### DIFF
--- a/src/components/helpers/wrapWithApiConnect.js
+++ b/src/components/helpers/wrapWithApiConnect.js
@@ -46,8 +46,9 @@ const wrapWithApiConnect = ({ finalMapPropsToPromiseProps, withRef }) => (Wrappe
         const promisePropUpdated = !prevPromiseProps[propName] ||
           !promisePropsEqual(promiseProp, prevPromiseProps[propName])
 
+        const fetchOnMount = !!props.fetchOnMount && prevProps === undefined
         const isInCache = !!props[propName].value
-        const needsFetch = !isInCache || ( // if not in cache or needs refresh
+        const needsFetch = fetchOnMount || !isInCache || ( // if not in cache or needs refresh
           promiseProp.refresh !== undefined &&
           promiseProp.refresh !== props[propName].refresh
         )

--- a/test/specs/components/connect.spec.js
+++ b/test/specs/components/connect.spec.js
@@ -117,6 +117,26 @@ describe('connect', () => {
     expect(reducerSpy).to.have.been.calledOnce
   })
 
+  it('should dispatch FETCH_DISPATCH action if `fetchOnMount` is true', () => {
+    mount(<TestContainer id="user-jane" fetchOnMount />)
+
+    expect(reducerSpy).to.have.been.calledOnce
+  })
+
+  it('should not dispatch FETCH_DISPATCH action if `fetchOnMount` is false', () => {
+    mount(<TestContainer id="user-jane" fetchOnMount={false} />)
+
+    expect(reducerSpy).to.have.not.been.called
+  })
+
+  it('should not dispatch FETCH_DISPATCH action if `fetchOnMount` is true and lifecycle event is not componentWillMount', () => {
+    const wrapper = mount(<TestContainer id="user-jane" />)
+    expect(reducerSpy).to.have.not.been.called
+
+    wrapper.setProps({ fetchOnMount: true })
+    expect(reducerSpy).to.have.not.been.called
+  })
+
   it('should not dispatch FETCH_DISPATCH action on update when promise props did not change', () => {
     const wrapper = mount(<TestContainer id={ data.user.id } />)
     reducerSpy.reset()


### PR DESCRIPTION
Force fetch from api on _componentWillMount_ **only** even though (_from the generic api perspective_) there are not such changes to be fetched. 

Use case:

1. Fetch a specific type from generic api
2. Change & update any of the containing objects and save them without using generic-api (common used in client)
3. Without refreshing the page, fetch again the same collection from step 1
4. The changes made on step 2 are not applied to the fetched objects from step 3

Client related issue: [#580](https://github.com/effektif/client/issues/580)