### PR TITLE
Add wipeReducer and clear generic-api state

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -69,6 +69,7 @@ export const actionTypes = {
   FETCH_FAILURE: 'GENERIC_API_FETCH_FAILURE',
   REMOVE_FAILURE: 'GENERIC_API_REMOVE_FAILURE',
   REQUEST_START: 'GENERIC_API_REQUEST_START',
+  WIPE_CACHE: 'GENERIC_API_WIPE_CACHE',
 }
 
 const actionCreatorMap: ActionCreatorMap = {
@@ -166,6 +167,11 @@ const actionCreatorMap: ActionCreatorMap = {
   },
 }
 
+// Non entityType specific action creator
+const wipe = () => ({
+  type: actionTypes.WIPE_CACHE,
+})
+
 
 const enhanceWithEntityTypeValidation
   = (types: ApiTypeMap, actionCreator: ActionCreator, actionCreatorName: string) =>
@@ -181,9 +187,12 @@ const enhanceWithEntityTypeValidation
   }
 
 
-const createActionCreators = (types: ApiTypeMap) => mapValues/*<ActionCreatorMap>*/(
-  actionCreatorMap,
-  enhanceWithEntityTypeValidation.bind(null, types)
-)
+const createActionCreators = (types: ApiTypeMap) => ({
+  ...mapValues/*<ActionCreatorMap>*/(
+    actionCreatorMap,
+    enhanceWithEntityTypeValidation.bind(null, types)
+  ),
+  wipe,
+})
 
 export default createActionCreators

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -9,8 +9,9 @@ import { getTypeNames, getCollectionName } from '../types'
 import createEntitiesReducer from './entitiesReducer'
 import createRequestsReducer from './requestsReducer'
 import createEnhanceWithSideEffects from './enhanceWithSideEffects'
+import createWipeReducer from './wipeReducer'
 
-export { createRequestsReducer, createEntitiesReducer }
+export { createRequestsReducer, createEntitiesReducer, createWipeReducer }
 
 const createReducer = (apiTypes: ApiTypeMap) => {
   const constants = getTypeNames(apiTypes)
@@ -20,7 +21,7 @@ const createReducer = (apiTypes: ApiTypeMap) => {
   )
   const enhanceWithSideEffects = createEnhanceWithSideEffects(apiTypes)
 
-  return enhanceWithSideEffects(
+  const apiReducer = enhanceWithSideEffects(
     combineReducers({
 
       entities: combineReducers(
@@ -39,6 +40,13 @@ const createReducer = (apiTypes: ApiTypeMap) => {
       ),
 
     })
+  )
+
+  const wipeReducer = (state, action) => createWipeReducer(state, action)
+
+  return reduceReducers(
+    wipeReducer,
+    apiReducer
   )
 }
 

--- a/src/reducers/wipeReducer.js
+++ b/src/reducers/wipeReducer.js
@@ -1,0 +1,12 @@
+import { actionTypes } from '../actions'
+
+const wipeReducer = (state = {}, action) => {
+  switch (action.type) {
+    case actionTypes.WIPE_CACHE:
+      return { }
+    default:
+      return state
+  }
+}
+
+export default wipeReducer

--- a/test/specs/reducers/wipeStateReducer.spec.js
+++ b/test/specs/reducers/wipeStateReducer.spec.js
@@ -1,0 +1,29 @@
+import expect from '../../expect'
+
+import createActionCreators from '../../../src/actions'
+import { createWipeReducer } from '../../../src/reducers'
+
+import { apiTypes } from '../fixtures'
+
+const actions = createActionCreators(apiTypes)
+
+const wipeReducer = createWipeReducer
+
+describe('wipeReducer', () => {
+  describe('WIPE_CACHE', () => {
+    it('should wipe cache', () => {
+      const state = {
+        entities: {},
+        requests: {},
+      }
+
+      const nextState = wipeReducer(
+        state,
+
+        actions.wipe()
+      )
+
+      expect(nextState).to.deep.equal({})
+    })
+  })
+})


### PR DESCRIPTION
I'm creating a wipeReducer so it get's easy to clear the whole generic-api state.

Use case: switch organization in the client.