### PR TITLE
Fix required values assumption in mapActionToEntity payload

### DIFF
--- a/src/sagas/watchUpdateDispatch.js
+++ b/src/sagas/watchUpdateDispatch.js
@@ -43,11 +43,12 @@ export function createUpdateDispatch(types: ApiTypeMap) {
 
 const mapActionToEntity = ({
   type,
-  payload: { entityType, query },
+  payload = {},
 }: Action) => {
   if (type !== actionTypes.UPDATE_DISPATCH) {
     return false
   }
+  const { entityType, query } = payload
   return `${entityType}_${stringifyQuery(query)}`
 }
 


### PR DESCRIPTION
Previously we always rely on having `entityType` and `query`  fields

```javascript
 const { entityType, query } = payload
```
in payload object but in some cases ( https://github.com/effektif/client/issues/1307 ) `payload` can be `undefined`.

