### PR TITLE
Dispatch success action for 204 response

### DIFF
--- a/src/sagas/watchFetchDispatch.js
+++ b/src/sagas/watchFetchDispatch.js
@@ -38,13 +38,13 @@ export const createFetchSaga = (types: ApiTypeMap) => {
       action.payload.body
     )
 
-    if (response) {
+    if (!error) {
       yield put(
         actionCreators.succeedFetch({
           entityType,
           requestId,
-          value: response.result,
-          entities: response.entities,
+          value: response && response.result,
+          entities: response && response.entities,
           isCachedResponse: false,
         })
       )

--- a/test/specs/sagas/watchFetchDispatch.spec.js
+++ b/test/specs/sagas/watchFetchDispatch.spec.js
@@ -93,4 +93,20 @@ describe('Saga - fetchSaga', () => {
       put(actions.failFetch({ entityType: types.USER, requestId, error }))
     )
   })
+
+  it('should dispatch success action if request is 204 (empty response)', () => {
+    generator.next()
+
+    expect(generator.next({ response: undefined }).value).to.deep.equal(
+      put(
+        actions.succeedFetch({
+          entityType: types.USER,
+          requestId,
+          value: undefined,
+          entities: undefined,
+          isCachedResponse: false,
+        })
+      )
+    )
+  })
 })


### PR DESCRIPTION
Issue found in WFA (https://github.com/signavio/workflow-client/issues/2683)

Whenever we've got a successful response without content (HTTP 204), kraken was dispatching a fail action. 