### PR TITLE
Added status code to dispatched request failure payloads

### DIFF
--- a/src/callApi.js
+++ b/src/callApi.js
@@ -5,13 +5,11 @@ import { bustRequest } from './utils'
 // Fetches an API response and normalizes the result JSON according to schema.
 // This makes every API response have the same shape, regardless of how nested it was.
 export default function callApi(fullUrl, schema, options) {
-  const url = (typeof fullUrl === 'function') ?
-    fullUrl() :
-    fullUrl
+  const url = typeof fullUrl === 'function' ? fullUrl() : fullUrl
   const finalUrl = bustRequest(url, options)
 
   return fetch(finalUrl, options)
-    .then((response) => {
+    .then(response => {
       let contentType = response.headers.get('Content-Type')
 
       if (contentType !== null) {
@@ -20,9 +18,11 @@ export default function callApi(fullUrl, schema, options) {
 
       switch (contentType) {
         case 'application/json':
-          return response.json().then((json) => ({ json, response }))
+          return response.json().then(json => ({ json, response }))
         case 'text/plain':
-          return response.text().then((text) => ({ json: { message: text }, response }))
+          return response
+            .text()
+            .then(text => ({ json: { message: text }, response }))
         default:
           if (response.status === 204) {
             return { response }
@@ -42,12 +42,17 @@ export default function callApi(fullUrl, schema, options) {
       return json ? normalize(json, schema) : null
     })
     .then(
-      (response) => ({ response }),
-      ({ json, response, message }) => ({
-        error: message ?
-          `Error parsing the response: ${message}` :
-            (json && json.message) ||
-            (response && response.statusText),
-      })
+      response => ({ response }),
+      ({ json, response, message }) => {
+        const result = {
+          error: message
+            ? `Error parsing the response: ${message}`
+            : (json && json.message) || (response && response.statusText),
+        }
+        if (response && response.status) {
+          result.status = response.status
+        }
+        return result
+      }
     )
 }

--- a/src/internalTypes/index.js
+++ b/src/internalTypes/index.js
@@ -144,24 +144,28 @@ export type CreateFailurePayload = {
   requestId: RequestId,
   entityType: string,
   error: string,
+  status?: number,
 }
 
 export type UpdateFailurePayload = {
   requestId: RequestId,
   entityType: string,
   error: string,
+  status?: number,
 }
 
 export type FetchFailurePayload = {
   requestId: RequestId,
   entityType: string,
   error: string,
+  status?: number,
 }
 
 export type RemoveFailurePayload = {
   requestId: RequestId,
   entityType: string,
   error: string,
+  status?: number,
 }
 
 export type FailurePayload =


### PR DESCRIPTION
I added the response status code to the dispatched request failure payload. It will help recognising requests which failed with a `401` where the user needs to login again.