### PR TITLE
Improvement/request params

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ Each type must export a certain set of attributes. These contain descriptions
 about the structure of each type and also methods to read, create or modify an
 instance of that type.
 
-| Attribute           | Required | Description                                                                                                                                                                                 |
-| ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| schema              | `true`   | A [normalizr](https://github.com/paularmstrong/normalizr) schema that is used to store and access your data.                                                                                |
-| collection          | `true`   | Identifier where all retrieved instances for that type will be stored.                                                                                                                      |
-| fetch(query, body)  | `false`  | A method that takes a custom set of properties and maps it to a call of [`callAPI`](https://github.com/signavio/generic-api/blob/master/src/callApi.js) to retrieve data from your backend. |
-| create(query, body) | `false`  | Function that describes how an instance is created.                                                                                                                                         |
-| update(query, body) | `false`  | Function that describes how an instance is updaetd.                                                                                                                                         |
-| remove(query, body) | `false`  | Function that describes how an instance is removed.                                                                                                                                         |
-| cachePolicy         | `false`  | The cache policy that should be used for that type. See [cache policies](TODO) for the possible options.                                                                                    |
+| Attribute                          | Required | Description                                                                                                                                                                                 |
+| ---------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| schema                             | `true`   | A [normalizr](https://github.com/paularmstrong/normalizr) schema that is used to store and access your data.                                                                                |
+| collection                         | `true`   | Identifier where all retrieved instances for that type will be stored.                                                                                                                      |
+| fetch(query, body, requestParams)  | `false`  | A method that takes a custom set of properties and maps it to a call of [`callAPI`](https://github.com/signavio/generic-api/blob/master/src/callApi.js) to retrieve data from your backend. |
+| create(query, body, requestParams) | `false`  | Function that describes how an instance is created.                                                                                                                                         |
+| update(query, body, requestParams) | `false`  | Function that describes how an instance is updaetd.                                                                                                                                         |
+| remove(query, body, requestParams) | `false`  | Function that describes how an instance is removed.                                                                                                                                         |
+| cachePolicy                        | `false`  | The cache policy that should be used for that type. See [cache policies](TODO) for the possible options.                                                                                    |
 
 ### `callApi(fullUrl, schema[, options])`
 
@@ -234,14 +234,15 @@ and created a new prop `userFetch` that represents the API request. You include
 certain configuration options to get more power over when and how requests go
 out.
 
-| Option      | Default     | Required | Description                                                                                                                                         |
-| ----------- | ----------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| type        | `undefined` | `true`   | The API type which is concered.                                                                                                                     |
-| query       | `undefined` | `false`  | An object of query parameters.                                                                                                                      |
-| id          | `undefined` | `false`  | Shortcut to provide an ID query parameter, `id: 1` is equivalent to `query: { id: 1 }`                                                              |
-| method      | `fetch`     | `false`  | Either one of `fetch`, `create`, `update`, or `remove`.                                                                                             |
-| lazy        | `false`     | `false`  | Only useful in combination with `method: 'fetch'`. Per default, the resource is fetched on component mount. Set `lazy: true` to not fetch on mount. |
-| denormalize | `false`     | `false`  | Inline all referenced data into the injected prop.                                                                                                  |
+| Option        | Default     | Required | Description                                                                                                                                         |
+| ------------- | ----------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type          | `undefined` | `true`   | The API type which is concered.                                                                                                                     |
+| query         | `undefined` | `false`  | An object of query parameters.                                                                                                                      |
+| requestParams | `undefined` |  `false` | An object of extra parameters to tell different requests apart.                                                                                     |
+| id            | `undefined` | `false`  | Shortcut to provide an ID query parameter, `id: 1` is equivalent to `query: { id: 1 }`                                                              |
+| method        | `fetch`     | `false`  | Either one of `fetch`, `create`, `update`, or `remove`.                                                                                             |
+| lazy          | `false`     | `false`  | Only useful in combination with `method: 'fetch'`. Per default, the resource is fetched on component mount. Set `lazy: true` to not fetch on mount. |
+| denormalize   | `false`     | `false`  | Inline all referenced data into the injected prop.                                                                                                  |
 
 #### Notes on using `denormalize: true`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signavio/kraken",
-  "version": "6.0.1",
+  "version": "6.1.0-0",
   "description": "Load API entities",
   "repository": "git@github.com:signavio/kraken.git",
   "main": "lib/index.js",

--- a/src/components/helpers/mapDispatchToPropsFactory.js
+++ b/src/components/helpers/mapDispatchToPropsFactory.js
@@ -40,7 +40,7 @@ const mapDispatchToPropsFactory = ({
       type: entityType,
       method,
       query = {},
-      requestParams,
+      requestParams = {},
       refresh,
       requiredFields,
     }) => {

--- a/src/components/helpers/mapDispatchToPropsFactory.js
+++ b/src/components/helpers/mapDispatchToPropsFactory.js
@@ -40,6 +40,7 @@ const mapDispatchToPropsFactory = ({
       type: entityType,
       method,
       query = {},
+      requestParams,
       refresh,
       requiredFields,
     }) => {
@@ -55,14 +56,23 @@ const mapDispatchToPropsFactory = ({
       switch (method) {
         case 'fetch':
           return (body: Body) =>
-            actionCreator({ entityType, query, refresh, requiredFields, body })
+            actionCreator({
+              entityType,
+              query,
+              requestParams,
+              refresh,
+              requiredFields,
+              body,
+            })
         case 'create':
           return (body: Body) =>
-            actionCreator({ entityType, elementId, query, body })
+            actionCreator({ entityType, elementId, query, requestParams, body })
         case 'update':
-          return (body: Body) => actionCreator({ entityType, query, body })
+          return (body: Body) =>
+            actionCreator({ entityType, query, requestParams, body })
         case 'remove':
-          return (body: Body) => actionCreator({ entityType, query, body })
+          return (body: Body) =>
+            actionCreator({ entityType, query, requestParams, body })
         default:
           throw new Error(`Unkown dispatch method ${method}`)
       }

--- a/src/components/helpers/mapStateToProps.js
+++ b/src/components/helpers/mapStateToProps.js
@@ -21,28 +21,35 @@ const mapStateToProps = ({ types, finalMapPropsToPromiseProps }) => () => {
     // function can figure out whether s.th. has changed
     const stateProps = {
       ...mapKeys(
-        mapValues(promiseProps, ({ query, type, method }, propName) =>
-          getRequestState(types, state, {
-            type: actionTypes[`${method.toUpperCase()}_DISPATCH`],
-            payload: {
-              entityType: type,
-              query,
-              elementId,
-              propName,
-            },
-          })
+        mapValues(
+          promiseProps,
+          ({ query, requestParams, type, method }, propName) =>
+            getRequestState(types, state, {
+              type: actionTypes[`${method.toUpperCase()}_DISPATCH`],
+              payload: {
+                entityType: type,
+                query,
+                requestParams,
+                elementId,
+                propName,
+              },
+            })
         ),
         (val, propName) => `${propName}_request`
       ),
       ...mapKeys(
         mapValues(
           promiseProps,
-          ({ query, refresh, type, method, denormalize }, propName) => {
+          (
+            { query, requestParams, refresh, type, method, denormalize },
+            propName
+          ) => {
             const entityState = getEntityState(types, state, {
               type: actionTypes[`${method.toUpperCase()}_DISPATCH`],
               payload: {
                 entityType: type,
                 query,
+                requestParams,
                 refresh,
                 elementId,
                 denormalizeValue: denormalize,

--- a/src/components/helpers/mergeProps.js
+++ b/src/components/helpers/mergeProps.js
@@ -1,9 +1,13 @@
 import { mapValues } from 'lodash'
 
-const mergeProps = ({ finalMapPropsToPromiseProps }) => (stateProps, dispatchProps, ownProps) => {
+const mergeProps = ({ finalMapPropsToPromiseProps }) => (
+  stateProps,
+  dispatchProps,
+  ownProps
+) => {
   const promiseProps = finalMapPropsToPromiseProps(ownProps)
 
-  const joinPromiseValue = (propName) => {
+  const joinPromiseValue = propName => {
     const promise = stateProps[`${propName}_request`]
     const entity = stateProps[`${propName}_entity`]
 
@@ -28,17 +32,19 @@ const mergeProps = ({ finalMapPropsToPromiseProps }) => (stateProps, dispatchPro
   }
 
   const mergePromiseStateToActionCreator = (propName, promiseState) => {
-    return Object.assign((...args) => dispatchProps[propName](...args), promiseState)
+    return Object.assign(
+      (...args) => dispatchProps[propName](...args),
+      promiseState
+    )
   }
 
   // now it's time to join the `${propName}_entity` with the `${propName}_request` props
   return {
     ...ownProps,
     ...dispatchProps,
-    ...mapValues(promiseProps, (value, propName) => mergePromiseStateToActionCreator(
-      propName,
-      joinPromiseValue(propName)
-    )),
+    ...mapValues(promiseProps, (value, propName) =>
+      mergePromiseStateToActionCreator(propName, joinPromiseValue(propName))
+    ),
   }
 }
 

--- a/src/reducers/requestsReducer.js
+++ b/src/reducers/requestsReducer.js
@@ -24,6 +24,7 @@ const requestsReducer = (state: RequestsState, action: Action) => {
           ...request,
           outstanding: true,
           query: payload.query,
+          requestParams: payload.requestParams,
           pending: true,
           refresh:
             payload.refresh !== undefined ? payload.refresh : request.refresh,

--- a/src/sagas/watchCreateDispatch.js
+++ b/src/sagas/watchCreateDispatch.js
@@ -15,7 +15,12 @@ export const createCreateDispatch = (types: ApiTypeMap) => {
     const entityType = action.payload.entityType
     const create = getCreate(types, entityType)
 
-    const result = yield call(create, action.payload.query, action.payload.body)
+    const result = yield call(
+      create,
+      action.payload.query,
+      action.payload.body,
+      action.payload.requestParams
+    )
 
     if (!result.error) {
       yield put(

--- a/src/sagas/watchFetchDispatch.js
+++ b/src/sagas/watchFetchDispatch.js
@@ -36,7 +36,8 @@ export const createFetchSaga = (types: ApiTypeMap) => {
     const { response, error, status } = yield call(
       fetch,
       action.payload.query,
-      action.payload.body
+      action.payload.body,
+      action.payload.requestParams
     )
 
     if (!error) {

--- a/src/sagas/watchRemoveDispatch.js
+++ b/src/sagas/watchRemoveDispatch.js
@@ -18,7 +18,8 @@ export function createRemoveDispatch(types: ApiTypeMap) {
     const { error, status } = yield call(
       remove,
       action.payload.query,
-      action.payload.body
+      action.payload.body,
+      action.payload.requestParams
     )
 
     if (!error) {

--- a/src/sagas/watchUpdateDispatch.js
+++ b/src/sagas/watchUpdateDispatch.js
@@ -19,7 +19,12 @@ export function createUpdateDispatch(types: ApiTypeMap) {
     const entityType = action.payload.entityType
 
     const update = getUpdate(types, entityType)
-    const result = yield call(update, action.payload.query, action.payload.body)
+    const result = yield call(
+      update,
+      action.payload.query,
+      action.payload.body,
+      action.payload.requestParams
+    )
 
     if (result.response) {
       yield put(

--- a/src/utils/deriveRequestIdFromAction.js
+++ b/src/utils/deriveRequestIdFromAction.js
@@ -36,7 +36,10 @@ const getMethodName = (action: Action) => {
 }
 
 const deriveRequestId = (action: DispatchAction): string => {
-  const stringifiedQuery = stringifyQuery(action.payload.query)
+  const stringifiedQuery = stringifyQuery({
+    ...action.payload.query,
+    ...action.payload.requestParams,
+  })
   const methodName = getMethodName(action)
   return action.type === actionTypes.CREATE_DISPATCH
     ? `${methodName}_${stringifiedQuery}_${action.payload.elementId}`

--- a/test/specs/components/connectWithRequestParams.spec.js
+++ b/test/specs/components/connectWithRequestParams.spec.js
@@ -1,0 +1,105 @@
+import React from 'react'
+import { createStore } from 'redux'
+import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
+import sinon from 'sinon'
+
+import createConnect from '../../../src/components'
+import { actionTypes } from '../../../src/actions'
+
+import expect from '../../expect'
+
+import { types, apiTypes, data } from '../fixtures'
+
+const connect = createConnect(apiTypes)
+
+const renderSpy = sinon.spy()
+
+const MyComp = props => {
+  renderSpy(props)
+  return <div />
+}
+
+const reducerSpy = sinon.spy((state = {}) => state)
+const testStore = createStore(reducerSpy, {
+  kraken: {
+    requests: {
+      [types.USER]: {},
+    },
+    entities: {
+      users: {},
+    },
+  },
+})
+
+const TestComponent = connect(({ offset = 0 }) => ({
+  fetchUser: {
+    type: types.USER,
+    requestParams: {
+      offset,
+      pageSize: 25,
+    },
+  },
+}))(MyComp)
+
+const TestContainer = props => (
+  <Provider store={testStore}>
+    <TestComponent {...props} />
+  </Provider>
+)
+
+describe('connectWithQuery', () => {
+  beforeEach(() => {
+    renderSpy.resetHistory()
+    reducerSpy.resetHistory()
+  })
+
+  it('should dispatch the FETCH_DISPATCH action on mount', () => {
+    mount(<TestContainer id={data.user.id} />)
+
+    expect(reducerSpy).to.have.been.calledOnce
+    expect(reducerSpy).to.have.been.calledWithMatch(testStore.getState(), {
+      type: actionTypes.FETCH_DISPATCH,
+      payload: {
+        entityType: types.USER,
+        requestParams: {
+          offset: 0,
+          pageSize: 25,
+        },
+      },
+    })
+  })
+
+  it('should dispatch the FETCH_DISPATCH action when the promise props update', () => {
+    const wrapper = mount(<TestContainer id={data.user.id} />)
+    reducerSpy.resetHistory()
+
+    expect(reducerSpy).to.have.not.been.called
+    wrapper.setProps({ offset: 25 })
+
+    expect(reducerSpy).to.have.been.calledOnce
+    expect(reducerSpy).to.have.been.calledWithMatch(testStore.getState(), {
+      type: actionTypes.FETCH_DISPATCH,
+      payload: {
+        entityType: types.USER,
+        requestParams: {
+          offset: 25,
+          pageSize: 25,
+        },
+      },
+    })
+  })
+
+  it('should not dispatch FETCH_DISPATCH action on update when promise props did not change', () => {
+    const wrapper = mount(<TestContainer id={data.user.id} />)
+
+    reducerSpy.resetHistory()
+    expect(reducerSpy).to.have.not.been.called
+    wrapper.setProps({ bla: 'blups' })
+
+    expect(reducerSpy).to.have.not.been.called
+    wrapper.update() // calls forceUpdate
+
+    expect(reducerSpy).to.have.not.been.called
+  })
+})

--- a/test/specs/components/helpers/mapDispatchToPropsFactory.spec.js
+++ b/test/specs/components/helpers/mapDispatchToPropsFactory.spec.js
@@ -14,6 +14,11 @@ const query = {
   someId: 'abcd123',
 }
 
+const requestParams = {
+  offset: 0,
+  pageSize: 25,
+}
+
 describe('helper - mapDispatchToPropsFactory', () => {
   let dispatch
 
@@ -29,6 +34,7 @@ describe('helper - mapDispatchToPropsFactory', () => {
         type: entityType,
         method: 'remove',
         query,
+        requestParams,
       },
     })
 
@@ -86,6 +92,21 @@ describe('helper - mapDispatchToPropsFactory', () => {
 
       expect(type).to.equal(actionTypes.REMOVE_DISPATCH)
       expect(payload).to.have.property('body', body)
+    })
+
+    it('should pass the request params to the action creator.', () => {
+      const { removeType } = promiseProps
+
+      expect(dispatch).to.not.have.been.called
+
+      removeType()
+
+      expect(dispatch).to.have.been.calledOnce
+
+      const { type, payload } = dispatch.getCall(0).args[0]
+
+      expect(type).to.eq(actionTypes.REMOVE_DISPATCH)
+      expect(payload).to.have.property('requestParams', requestParams)
     })
   })
 })

--- a/test/specs/fixtures/types/comments.js
+++ b/test/specs/fixtures/types/comments.js
@@ -1,0 +1,12 @@
+// @flow
+import { schema as schemas } from 'normalizr'
+
+import { callApi } from '../../../../src'
+
+import { schema as commentSchema } from './comment'
+
+export { collection } from './comment'
+
+export const schema = new schemas.Array(commentSchema)
+
+export const fetch = () => callApi(`/comments`, schema)

--- a/test/specs/fixtures/types/index.js
+++ b/test/specs/fixtures/types/index.js
@@ -3,6 +3,7 @@ import * as USERS from './users'
 import * as POST from './post'
 import * as POSTS from './posts'
 import * as COMMENT from './comment'
+import * as COMMENTS from './comments'
 
 export default {
   USER,
@@ -10,4 +11,5 @@ export default {
   POST,
   POSTS,
   COMMENT,
+  COMMENTS,
 }

--- a/test/specs/integration/createDispatchActions.spec.js
+++ b/test/specs/integration/createDispatchActions.spec.js
@@ -88,6 +88,7 @@ describe('Integration - dispatch create actions', () => {
             title: 'Very new post',
             description: 'All the infos here',
           },
+          requestParams: {},
         })
       )
       expect(actions[1]).to.deep.equal(
@@ -136,6 +137,7 @@ describe('Integration - dispatch create actions', () => {
             title: 'Very new post',
             description: 'All the infos here',
           },
+          requestParams: {},
         })
       )
       expect(actions[1]).to.deep.equal(
@@ -177,6 +179,7 @@ describe('Integration - dispatch create actions', () => {
             title: 'Very new post',
             description: 'All the infos here',
           },
+          requestParams: {},
         })
       )
       expect(actions[1]).to.deep.equal(

--- a/test/specs/integration/fetchArguments.spec.js
+++ b/test/specs/integration/fetchArguments.spec.js
@@ -96,7 +96,7 @@ describe('Integration - fetch', () => {
       expect(fetch).to.have.been.calledWith(query)
 
       done()
-    })
+    }, 2)
   })
 
   it('should pass the body to the fetch action', done => {

--- a/test/specs/integration/removeDispatchActions.spec.js
+++ b/test/specs/integration/removeDispatchActions.spec.js
@@ -79,6 +79,7 @@ describe('Integration - dispatch remove actions', () => {
             id: data.post.id,
           },
           body: undefined,
+          requestParams: {},
         })
       )
       expect(actions[1]).to.deep.equal(
@@ -111,6 +112,7 @@ describe('Integration - dispatch remove actions', () => {
             id: data.post.id,
           },
           body: undefined,
+          requestParams: {},
         })
       )
       expect(actions[1]).to.deep.equal(

--- a/test/specs/integration/updateDispatchActions.spec.js
+++ b/test/specs/integration/updateDispatchActions.spec.js
@@ -89,6 +89,7 @@ describe('Integration - dispatch update actions', () => {
             title: 'Updated post',
             description: 'All the infos here',
           },
+          requestParams: {},
         })
       )
       expect(actions[1]).to.deep.equal(
@@ -139,6 +140,7 @@ describe('Integration - dispatch update actions', () => {
             title: 'Updated post',
             description: 'All the infos here',
           },
+          requestParams: {},
         })
       )
       expect(actions[1]).to.deep.equal(

--- a/test/specs/reducers/requestReducer.spec.js
+++ b/test/specs/reducers/requestReducer.spec.js
@@ -25,6 +25,31 @@ describe('requestReducer', () => {
   const requestsReducerForEntity = createRequestsReducer(apiTypes, types.USER)
 
   describe('FETCH_DISPATCH', () => {
+    it('should include request parameters in the request.', () => {
+      const requestParams = {
+        offset: 0,
+        pageSize: 25,
+      }
+
+      const newState = requestsReducerForEntity(
+        {},
+        actions.dispatchFetch({ entityType: types.USER, requestParams })
+      )
+
+      const newRequestId = deriveRequestIdFromAction({
+        type: actionTypes.FETCH_DISPATCH,
+        payload: {
+          requestParams,
+        },
+      })
+
+      expect(newState).to.have.property(newRequestId)
+      expect(newState[newRequestId]).to.have.property(
+        'requestParams',
+        requestParams
+      )
+    })
+
     it('should set pending and outstanding flags', () => {
       const newState = requestsReducerForEntity(
         {},

--- a/test/specs/sagas/watchCreateDispatch.spec.js
+++ b/test/specs/sagas/watchCreateDispatch.spec.js
@@ -44,7 +44,7 @@ describe('Saga - createEntity', () => {
 
   it('should call the `create` function of the entity type passing in the query object', () => {
     expect(generator.next().value).to.deep.equal(
-      call(typeUtils.getCreate(apiTypes, types.USER), {}, body)
+      call(typeUtils.getCreate(apiTypes, types.USER), {}, body, undefined)
     )
   })
 

--- a/test/specs/sagas/watchFetchDispatch.spec.js
+++ b/test/specs/sagas/watchFetchDispatch.spec.js
@@ -60,7 +60,7 @@ describe('Saga - fetchSaga', () => {
 
   it('should call the `fetch` function of the entity type passing in the query object', () => {
     expect(generator.next().value).to.deep.equal(
-      call(getFetch(apiTypes, types.USER), query, undefined)
+      call(getFetch(apiTypes, types.USER), query, undefined, undefined)
     )
   })
 

--- a/test/specs/utils/deriveRequestIdFromAction.spec.js
+++ b/test/specs/utils/deriveRequestIdFromAction.spec.js
@@ -1,0 +1,66 @@
+import createActionCreators from '../../../src/actions'
+import { deriveRequestIdFromAction } from '../../../src/utils'
+
+import expect from '../../expect'
+
+import { apiTypes, types } from '../fixtures'
+
+const actionTypes = ['Fetch', 'Update', 'Remove']
+
+const actions = createActionCreators(apiTypes)
+
+describe('deriveRequestIdFromAction', () => {
+  const query = {
+    id: 'abc123',
+  }
+
+  const requestParams = {
+    offset: 0,
+  }
+
+  const createAction = (actionType, payload) =>
+    actions[`dispatch${actionType}`]({
+      entityType: types.USER,
+      ...payload,
+    })
+
+  actionTypes.forEach(actionType => {
+    describe(`dispatch${actionType}`, () => {
+      it('should derive a request id without query and params', () => {
+        const action = createAction(actionType)
+
+        const requestId = deriveRequestIdFromAction(action)
+
+        expect(requestId).to.equal(`${actionType.toLowerCase()}_`)
+      })
+
+      it('should derive a request id with query', () => {
+        const action = createAction(actionType, { query })
+
+        const requestId = deriveRequestIdFromAction(action)
+
+        expect(requestId).to.equal(
+          `${actionType.toLowerCase()}_["id","abc123"]`
+        )
+      })
+
+      it('should derive a request id with request params', () => {
+        const action = createAction(actionType, { requestParams })
+
+        const requestId = deriveRequestIdFromAction(action)
+
+        expect(requestId).to.equal(`${actionType.toLowerCase()}_["offset",0]`)
+      })
+
+      it('should derive a request id with request params and query', () => {
+        const action = createAction(actionType, { query, requestParams })
+
+        const requestId = deriveRequestIdFromAction(action)
+
+        expect(requestId).to.equal(
+          `${actionType.toLowerCase()}_["id","abc123"]["offset",0]`
+        )
+      })
+    })
+  })
+})


### PR DESCRIPTION
I added a new mechanism called `requestParams` that allows the user to hand over parameters that should not be matched against entities in our cache. 

These parameters will influence the `id` of each request which makes it possible to, for instance, realize pagination. 