### PR TITLE
[WIP] Extend create request to support refresh option

### DIFF
--- a/src/components/helpers/mapDispatchToPropsFactory.js
+++ b/src/components/helpers/mapDispatchToPropsFactory.js
@@ -66,7 +66,7 @@ const mapDispatchToPropsFactory = ({
             })
         case 'create':
           return (body: Body) =>
-            actionCreator({ entityType, elementId, query, requestParams, body })
+            actionCreator({ entityType, elementId, query, requestParams, refresh, body })
         case 'update':
           return (body: Body) =>
             actionCreator({ entityType, query, requestParams, body })

--- a/src/components/helpers/mapDispatchToPropsFactory.js
+++ b/src/components/helpers/mapDispatchToPropsFactory.js
@@ -49,7 +49,7 @@ const mapDispatchToPropsFactory = ({
         !!actionCreator,
         `Unknown method '${method}' specified ` +
           `(supported values: ${validMethods
-            .map((validMathod: string) => `'${validMathod}'`)
+            .map((validMethod: string) => `'${validMethod}'`)
             .join(', ')})`
       )
 
@@ -74,7 +74,7 @@ const mapDispatchToPropsFactory = ({
           return (body: Body) =>
             actionCreator({ entityType, query, requestParams, body })
         default:
-          throw new Error(`Unkown dispatch method ${method}`)
+          throw new Error(`Unknown dispatch method ${method}`)
       }
     }
 

--- a/src/components/helpers/mapDispatchToPropsFactory.js
+++ b/src/components/helpers/mapDispatchToPropsFactory.js
@@ -66,7 +66,14 @@ const mapDispatchToPropsFactory = ({
             })
         case 'create':
           return (body: Body) =>
-            actionCreator({ entityType, elementId, query, requestParams, refresh, body })
+            actionCreator({
+              entityType,
+              elementId,
+              query,
+              requestParams,
+              refresh,
+              body,
+            })
         case 'update':
           return (body: Body) =>
             actionCreator({ entityType, query, requestParams, body })

--- a/test/specs/components/helpers/mapDispatchToPropsFactory.spec.js
+++ b/test/specs/components/helpers/mapDispatchToPropsFactory.spec.js
@@ -14,6 +14,10 @@ const query = {
   someId: 'abcd123',
 }
 
+const refresh = {
+  id: 'unique',
+}
+
 const requestParams = {
   offset: 0,
   pageSize: 25,
@@ -107,6 +111,56 @@ describe('helper - mapDispatchToPropsFactory', () => {
 
       expect(type).to.eq(actionTypes.REMOVE_DISPATCH)
       expect(payload).to.have.property('requestParams', requestParams)
+    })
+  })
+
+  describe('create', () => {
+    let promiseProps
+
+    const finalMapPropsToPromiseProps = () => ({
+      createType: {
+        type: entityType,
+        method: 'create',
+        query,
+        refresh,
+      },
+    })
+
+    beforeEach(() => {
+      promiseProps = mapDispatchToPropsFactory({
+        types,
+        finalMapPropsToPromiseProps,
+      })()(dispatch, {})
+    })
+
+    it('should include the query in the action creator ', () => {
+      const { createType } = promiseProps
+
+      expect(dispatch).to.not.have.been.called
+
+      createType()
+
+      expect(dispatch).to.have.been.calledOnce
+
+      const { type, payload } = dispatch.getCall(0).args[0]
+
+      expect(type).to.eq(actionTypes.CREATE_DISPATCH)
+      expect(payload).to.have.property('query', query)
+    })
+
+    it('should include the refresh in the action creator', () => {
+      const { createType } = promiseProps
+
+      expect(dispatch).to.not.have.been.called
+
+      createType()
+
+      expect(dispatch).to.have.been.calledOnce
+
+      const { type, payload } = dispatch.getCall(0).args[0]
+
+      expect(type).to.eq(actionTypes.CREATE_DISPATCH)
+      expect(payload).to.have.property('refresh', refresh)
     })
   })
 })


### PR DESCRIPTION
This PR extends create request to support refresh option similar to `case 'fetch'`. Use case for this which we face in SWA is that after initial `POST` request to endpoint I receive field `errors` with error messages on response, after second request server response doesn't contain `errors: {}` but it is present in the `kraken` cache (read store). 

- Included refresh property in create action creator
- Fixed typos along the way
- Added tests for create case in `mapDispatchToPropsFactory.spec.js`