### PR TITLE
Include request body in state of a create, update, delete and fetch request

### DIFF
--- a/src/reducers/requestsReducer.js
+++ b/src/reducers/requestsReducer.js
@@ -26,6 +26,7 @@ const requestsReducer = (state: RequestsState, action: Action) => {
           ...request,
           outstanding: true,
           query: payload.query,
+          body: payload.body,
           requestParams: payload.requestParams,
           pending: true,
           refresh:

--- a/test/specs/reducers/requestReducer.spec.js
+++ b/test/specs/reducers/requestReducer.spec.js
@@ -146,6 +146,81 @@ describe('requestReducer', () => {
     })
   })
 
+  describe('CREATE_DISPATCH', () => {
+    it('should include request body in a create user request.', () => {
+      const body = {
+        emailAddress: 'new-user@signavio.com',
+      }
+
+      const newState = requestsReducerForEntity(
+        {},
+        actions.dispatchCreate({
+          entityType: types.USER,
+          body,
+        })
+      )
+
+      const newRequestId = deriveRequestIdFromAction({
+        type: actionTypes.CREATE_DISPATCH,
+        payload: {
+          body,
+        },
+      })
+
+      expect(newState).to.have.property(newRequestId)
+      expect(newState[newRequestId]).to.have.property('body', body)
+    })
+
+    it('should have undefined body if the request does not include a body.', () => {
+      const body = undefined
+
+      const newState = requestsReducerForEntity(
+        {},
+        actions.dispatchCreate({
+          entityType: types.USER,
+          body,
+        })
+      )
+
+      const newRequestId = deriveRequestIdFromAction({
+        type: actionTypes.CREATE_DISPATCH,
+        payload: {
+          body,
+        },
+      })
+
+      expect(newState).to.have.property(newRequestId)
+      expect(newState[newRequestId]).to.have.property('body', undefined)
+    })
+  })
+
+  describe('CREATE_SUCCESS', () => {
+    it('should include body in a succeeded create user request.', () => {
+      const body = {
+        emailAddress: 'new-user@signavio.com',
+      }
+
+      const requestId = deriveRequestIdFromAction({
+        type: actionTypes.CREATE_SUCCESS,
+        payload: {
+          body,
+        },
+      })
+
+      const newState = requestsReducerForEntity(
+        { [requestId]: {} },
+        actions.succeedCreate({
+          requestId,
+          entityType: types.USER,
+          body,
+        })
+      )
+
+      expect(newState).to.have.property(requestId)
+      expect(newState[requestId]).to.have.property('body', body)
+    })
+  })
+
   describe('FETCH_SUCCESS', () => {
     it('should set the promise state to fulfilled when cached', () => {
       const newState = requestsReducerForEntity(

--- a/test/specs/reducers/requestReducer.spec.js
+++ b/test/specs/reducers/requestReducer.spec.js
@@ -220,7 +220,6 @@ describe('requestReducer', () => {
         actions.succeedCreate({
           requestId,
           entityType: types.USER,
-          body,
         })
       )
 

--- a/test/specs/reducers/requestReducer.spec.js
+++ b/test/specs/reducers/requestReducer.spec.js
@@ -195,20 +195,28 @@ describe('requestReducer', () => {
   })
 
   describe('CREATE_SUCCESS', () => {
-    it('should include body in a succeeded create user request.', () => {
+    it('should include body in a succeeded create user request from initial create dispatch request.', () => {
       const body = {
         emailAddress: 'new-user@signavio.com',
       }
 
+      const initialState = requestsReducerForEntity(
+        {},
+        actions.dispatchCreate({
+          entityType: types.USER,
+          body,
+        })
+      )
+
       const requestId = deriveRequestIdFromAction({
-        type: actionTypes.CREATE_SUCCESS,
+        type: actionTypes.CREATE_DISPATCH,
         payload: {
           body,
         },
       })
 
       const newState = requestsReducerForEntity(
-        { [requestId]: {} },
+        initialState,
         actions.succeedCreate({
           requestId,
           entityType: types.USER,


### PR DESCRIPTION
Fixes #299 

In order to make better assertions on tests we would like to pass the body of request to Kraken request state so we know what is being sent. 

__How to test__
Make a fetch, create, update or remove request with content in the message bod and you should be able to see the body in the redux dev tools