### PR TITLE
Bugfix/correctly refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signavio/kraken",
-  "version": "7.1.0",
+  "version": "7.1.1-0",
   "description": "Load API entities",
   "repository": "git@github.com:signavio/kraken.git",
   "main": "lib/index.js",

--- a/src/components/helpers/wrapWithApiConnect.js
+++ b/src/components/helpers/wrapWithApiConnect.js
@@ -41,9 +41,11 @@ const wrapWithApiConnect = ({
         const hasNewRefreshToken =
           promiseProp.refresh !== undefined &&
           promiseProp.refresh !== fetchProp.refresh
-        const needsFetch = !isInCache || hasNewRefreshToken
 
-        if (promisePropUpdated && needsFetch && !promiseProp.lazy) {
+        if (
+          ((promisePropUpdated && !isInCache) || hasNewRefreshToken) &&
+          !promiseProp.lazy
+        ) {
           fetchProp()
         }
       })

--- a/test/specs/components/connect.spec.js
+++ b/test/specs/components/connect.spec.js
@@ -213,12 +213,15 @@ describe('connect', () => {
   it('should not dispatch FETCH_DISPATCH action on update when promise props did not change', () => {
     const wrapper = mount(<TestContainer id={data.user.id} />)
     reducerSpy.resetHistory()
+
     expect(reducerSpy).to.have.not.been.called
 
     wrapper.setProps({ bla: 'blups' })
+
     expect(reducerSpy).to.have.not.been.called
 
     wrapper.update() // calls forceUpdate
+
     expect(reducerSpy).to.have.not.been.called
   })
 
@@ -299,26 +302,26 @@ describe('connect', () => {
       return <div ref={ref}>Text</div>
     }
 
-
     const CompWithRefs = forwardRef(Component)
 
-    const ConnectedComponent = connect(
-      ({ id }) => ({
-        traceFetch: {
-          type: types.USER,
-          id,
-        },
-      }),
-    )(CompWithRefs)
+    const ConnectedComponent = connect(({ id }) => ({
+      traceFetch: {
+        type: types.USER,
+        id,
+      },
+    }))(CompWithRefs)
 
-    it('should return the wrapped instance', (done) => {
+    it('should return the wrapped instance', done => {
       mount(
         <Provider store={testStore}>
-          <ConnectedComponent id={data.user.id} ref={(ref) => {
-            expect(ref).to.exist
+          <ConnectedComponent
+            id={data.user.id}
+            ref={ref => {
+              expect(ref).to.exist
 
-            done()
-          }} />
+              done()
+            }}
+          />
         </Provider>
       )
     })


### PR DESCRIPTION
Changes how it is determined whether a re-fetch should happen.

- if `promiseProp` has changed and those changed lead to it not being in the cache
- **OR** the `refresh` token has changed
- **AND** the whole thing is not marked as `lazy`