### PR TITLE
Do not reset value when refresh token is set

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 85%

--- a/src/utils/getCachedValue.js
+++ b/src/utils/getCachedValue.js
@@ -1,7 +1,6 @@
 import { findKey } from 'lodash'
 
 import { hasEntitySchema } from '../types'
-import { actionTypes } from '../actions'
 import { State, ApiTypeMap, DispatchAction, EntityId } from '../flowTypes'
 
 import getRequestState from './getRequestState'
@@ -16,12 +15,6 @@ const getCachedValue = (
 
   if (requestState === undefined) {
     requestState = {}
-  }
-
-  if (action.type === actionTypes.FETCH_DISPATCH) {
-    if (action.payload.refresh !== undefined && action.payload.refresh !== requestState.refresh) {
-      return undefined
-    }
   }
 
   const entityType = action.payload.entityType

--- a/test/specs/utils/getCachedValue.spec.js
+++ b/test/specs/utils/getCachedValue.spec.js
@@ -7,7 +7,7 @@ import { apiTypes, types, data } from '../fixtures'
 
 const fetchAction = {
   type: actionTypes.FETCH_DISPATCH,
-  payload: { entityType: types.USER, query: { id: data.user.id } }
+  payload: { entityType: types.USER, query: { id: data.user.id } },
 }
 
 describe('Utils - getCachedValue', () => {
@@ -40,33 +40,6 @@ describe('Utils - getCachedValue', () => {
 
     expect(result).to.not.be.undefined
     expect(result).to.equal(data.user.id)
-  })
-
-  it('should not return a value if the refresh option is set.', () => {
-    const state = {
-      kraken: {
-        requests: {},
-        entities: {
-          [apiTypes.USER.collection]: {
-            [data.user.id]: data.user,
-          },
-        },
-      },
-    }
-
-    let result = getCachedValue(apiTypes, state, fetchAction)
-
-    expect(result).to.equal(data.user.id)
-
-    result = getCachedValue(apiTypes, state, {
-      type: fetchAction.type,
-      payload: {
-        ...fetchAction.payload,
-        refresh: true,
-      },
-    })
-
-    expect(result).to.be.undefined
   })
 
   it('should return the current promise value if the value has not been loaded.', () => {


### PR DESCRIPTION
Fixes #259 

**What has changed**
- Remove feature that set value to null when there is a refresh token, instead we keep the old value until a new one is returned 