### PR TITLE
Bugfix/correctly detect error

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -9,3 +9,4 @@
 [libs]
 
 [options]
+esproposal.optional_chaining=enable

--- a/src/callApi.js
+++ b/src/callApi.js
@@ -5,16 +5,14 @@ import { normalize, schema as schemas } from 'normalizr'
 
 import { bustRequest } from './utils'
 
-type FetchOptions = {|
-  body?: FormData | JSON,
-|}
+type Url = string | (() => string)
 
 // Fetches an API response and normalizes the result JSON according to schema.
 // This makes every API response have the same shape, regardless of how nested it was.
 export default async function callApi(
-  fullUrl: string,
+  fullUrl: Url,
   schema: schemas.Entity | schemas.Array,
-  options: FetchOptions = Object.freeze({})
+  options?: RequestOptions = Object.freeze({})
 ) {
   const url = typeof fullUrl === 'function' ? fullUrl() : fullUrl
 

--- a/src/sagas/watchCreateDispatch.js
+++ b/src/sagas/watchCreateDispatch.js
@@ -1,4 +1,4 @@
-import { get, isNil, omitBy } from 'lodash'
+import { isNil, omitBy } from 'lodash'
 import { call, put, takeEvery } from 'redux-saga/effects'
 
 import createActionCreators, { actionTypes } from '../actions'
@@ -42,8 +42,8 @@ export const createCreateDispatch = (types: ApiTypeMap) => {
         actionCreators.succeedCreate({
           entityType,
           requestId,
-          value: get(result, 'response.result'),
-          entities: get(result, 'response.entities', {}),
+          value: result.response?.result,
+          entities: result.response?.entities || {},
         })
       )
     } else {

--- a/src/sagas/watchCreateDispatch.js
+++ b/src/sagas/watchCreateDispatch.js
@@ -37,7 +37,7 @@ export const createCreateDispatch = (types: ApiTypeMap) => {
       action.payload.requestParams
     )
 
-    if (!result.error) {
+    if (result.error == null) {
       yield put(
         actionCreators.succeedCreate({
           entityType,

--- a/src/sagas/watchFetchDispatch.js
+++ b/src/sagas/watchFetchDispatch.js
@@ -49,7 +49,7 @@ export const createFetchSaga = (types: ApiTypeMap) => {
       action.payload.requestParams
     )
 
-    if (!error) {
+    if (error == null) {
       yield put(
         actionCreators.succeedFetch({
           entityType,

--- a/src/sagas/watchRemoveDispatch.js
+++ b/src/sagas/watchRemoveDispatch.js
@@ -37,7 +37,7 @@ export function createRemoveDispatch(types: ApiTypeMap) {
       action.payload.requestParams
     )
 
-    if (!error) {
+    if (error == null) {
       yield put(
         actions.succeedRemove({
           entityType,

--- a/src/sagas/watchUpdateDispatch.js
+++ b/src/sagas/watchUpdateDispatch.js
@@ -42,13 +42,13 @@ export function createUpdateDispatch(types: ApiTypeMap) {
       action.payload.requestParams
     )
 
-    if (result.response) {
+    if (result.error == null) {
       yield put(
         actions.succeedUpdate({
           entityType,
           requestId,
-          value: result.response.result,
-          entities: result.response.entities,
+          value: result.response?.result,
+          entities: result.response?.entities || {},
         })
       )
     } else {
@@ -75,7 +75,7 @@ export default function createWatchUpdateDispatch(types: ApiTypeMap) {
   const updateDispatch = createUpdateDispatch(types)
 
   return function* watchUpdateDispatch(getState) {
-    yield takeLatestOfEvery(mapActionToEntity, action =>
+    yield takeLatestOfEvery(mapActionToEntity, (action) =>
       updateDispatch(action, getState)
     )
   }

--- a/src/utils/bustRequest.js
+++ b/src/utils/bustRequest.js
@@ -1,4 +1,6 @@
-export default function bustRequest(url, options) {
+// @flow
+
+export default function bustRequest(url: string, options: ?RequestOptions) {
   const method = options?.method || 'GET'
   if (method !== 'GET') {
     return url

--- a/src/utils/bustRequest.js
+++ b/src/utils/bustRequest.js
@@ -1,7 +1,5 @@
-import { get } from 'lodash'
-
 export default function bustRequest(url, options) {
-  const method = get(options, 'method', 'GET')
+  const method = options?.method || 'GET'
   if (method !== 'GET') {
     return url
   }

--- a/test/specs/fixtures/types/user.js
+++ b/test/specs/fixtures/types/user.js
@@ -15,3 +15,6 @@ export const fetch = (callApi: CallApi) => ({ id }: { id: string }) =>
 
 export const create = (callApi: CallApi) => (_: any, body: JSON) =>
   callApi('/users/', schema, { method: 'POST', body })
+
+export const remove = (callApi: CallApi) => (_: any, body: JSON) =>
+  callApi('/users/', schema, { method: 'DELETE', body })

--- a/test/specs/fixtures/types/user.js
+++ b/test/specs/fixtures/types/user.js
@@ -16,5 +16,12 @@ export const fetch = (callApi: CallApi) => ({ id }: { id: string }) =>
 export const create = (callApi: CallApi) => (_: any, body: JSON) =>
   callApi('/users/', schema, { method: 'POST', body })
 
-export const remove = (callApi: CallApi) => (_: any, body: JSON) =>
-  callApi('/users/', schema, { method: 'DELETE', body })
+export const update = (callApi: CallApi) => (
+  { id }: { id: string },
+  body: JSON
+) => callApi(`/users/${id}`, schema, { method: 'PUT', body })
+
+export const remove = (callApi: CallApi) => (
+  { id }: { id: string },
+  body: JSON
+) => callApi(`/users/${id}`, schema, { method: 'DELETE', body })

--- a/test/specs/sagas/watchCreateDispatch.spec.js
+++ b/test/specs/sagas/watchCreateDispatch.spec.js
@@ -90,6 +90,16 @@ describe('Saga - createEntity', () => {
     )
   })
 
+  it('should dispatch an `error` action even if the error message is empty', () => {
+    generator.next()
+
+    const error = ''
+
+    expect(generator.next({ error }).value).to.deep.equal(
+      put(actions.failCreate({ entityType: types.USER, requestId, error }))
+    )
+  })
+
   it('should not create an `error` if the server returns an empty response.', () => {
     generator.next()
 

--- a/test/specs/sagas/watchFetchDispatch.spec.js
+++ b/test/specs/sagas/watchFetchDispatch.spec.js
@@ -38,13 +38,6 @@ const state = {
 const getState = () => state
 
 describe('Saga - fetchSaga', () => {
-  describe('Cached', () => {
-    it('should call `fetchSaga` the entity is not already cached')
-    it(
-      'should dispatch a `cacheHit` action if the entity is already in the cache'
-    )
-  })
-
   let generator
 
   beforeEach(() => {
@@ -94,6 +87,16 @@ describe('Saga - fetchSaga', () => {
     generator.next()
 
     const error = 'Some error message'
+
+    expect(generator.next({ error }).value).to.deep.equal(
+      put(actions.failFetch({ entityType: types.USER, requestId, error }))
+    )
+  })
+
+  it('should dispatch an `error` action even if the error message is empty', () => {
+    generator.next()
+
+    const error = ''
 
     expect(generator.next({ error }).value).to.deep.equal(
       put(actions.failFetch({ entityType: types.USER, requestId, error }))

--- a/test/specs/sagas/watchRemoveDispatch.spec.js
+++ b/test/specs/sagas/watchRemoveDispatch.spec.js
@@ -1,0 +1,121 @@
+import { normalize } from 'normalizr'
+import { put } from 'redux-saga/effects'
+
+import actionsCreator, { actionTypes } from '../../../src/actions'
+import { createRemoveDispatch } from '../../../src/sagas/watchRemoveDispatch'
+import { deriveRequestIdFromAction } from '../../../src/utils'
+import expect from '../../expect'
+import { apiTypes, data, types } from '../fixtures'
+
+const removeEntity = createRemoveDispatch(apiTypes)
+const actions = actionsCreator(apiTypes)
+
+const entityType = types.USER
+const query = {}
+const body = data.user
+
+const removePayload = {
+  entityType,
+  body,
+  query,
+}
+
+const removeAction = {
+  type: actionTypes.REMOVE_DISPATCH,
+  payload: removePayload,
+}
+
+const requestId = deriveRequestIdFromAction(removeAction)
+
+const state = {
+  kraken: {
+    requests: {
+      [types.USER]: {
+        [requestId]: {
+          outstanding: true,
+        },
+      },
+    },
+    entities: {
+      [types.USER]: {},
+    },
+
+    metaData: {},
+  },
+}
+
+const getState = () => state
+
+describe('Saga - removeEntity', () => {
+  let generator
+
+  beforeEach(() => {
+    generator = removeEntity(removeAction, getState)
+  })
+
+  it('should call the `remove` function of the entity type passing in the query object', () => {
+    expect(generator.next().value.payload)
+      .to.have.property('args')
+      .that.is.eql([{}, body, undefined])
+  })
+
+  it('should dispatch the `success` action with the server positively responds', () => {
+    generator.next()
+
+    const { result } = normalize(body, apiTypes.USER.schema)
+
+    expect(generator.next({ response: { result } }).value).to.deep.equal(
+      put(
+        actions.succeedRemove({
+          entityType,
+          requestId: deriveRequestIdFromAction(removeAction),
+        })
+      )
+    )
+  })
+
+  it('should dispatch an `error` action if the server request fails', () => {
+    generator.next()
+
+    const error = 'Some error message'
+
+    expect(generator.next({ error }).value).to.deep.equal(
+      put(actions.failRemove({ entityType: types.USER, requestId, error }))
+    )
+  })
+
+  it('should dispatch an `error` action even if the error message is empty', () => {
+    generator.next()
+
+    const error = ''
+
+    expect(generator.next({ error }).value).to.deep.equal(
+      put(actions.failRemove({ entityType: types.USER, requestId, error }))
+    )
+  })
+
+  it('should not create an `error` if the server returns an empty response.', () => {
+    generator.next()
+
+    const response = null
+
+    expect(generator.next({ response }).value).to.not.deep.equal(
+      put(actions.failRemove({ entityType: types.USER, requestId }))
+    )
+  })
+
+  it('should create an empty action if the server responds with an empty result.', () => {
+    generator.next()
+
+    const response = null
+
+    expect(generator.next({ response }).value).to.deep.equal(
+      put(
+        actions.succeedRemove({
+          entityType: types.USER,
+          requestId,
+        })
+      )
+    )
+  })
+})

--- a/test/specs/sagas/watchUpdateDispatch.spec.js
+++ b/test/specs/sagas/watchUpdateDispatch.spec.js
@@ -1,0 +1,127 @@
+import { normalize } from 'normalizr'
+import { put } from 'redux-saga/effects'
+
+import actionsCreator, { actionTypes } from '../../../src/actions'
+import { createUpdateDispatch } from '../../../src/sagas/watchUpdateDispatch'
+import { deriveRequestIdFromAction } from '../../../src/utils'
+import expect from '../../expect'
+import { apiTypes, data, types } from '../fixtures'
+
+const updateEntity = createUpdateDispatch(apiTypes)
+const actions = actionsCreator(apiTypes)
+
+const entityType = types.USER
+const query = {}
+const body = data.user
+
+const updatePayload = {
+  entityType,
+  body,
+  query,
+}
+
+const createAction = {
+  type: actionTypes.CREATE_DISPATCH,
+  payload: updatePayload,
+}
+
+const requestId = deriveRequestIdFromAction(createAction)
+
+const state = {
+  kraken: {
+    requests: {
+      [types.USER]: {
+        [requestId]: {
+          outstanding: true,
+        },
+      },
+    },
+    entities: {
+      [types.USER]: {},
+    },
+
+    metaData: {},
+  },
+}
+
+const getState = () => state
+
+describe('Saga - updateEntity', () => {
+  let generator
+
+  beforeEach(() => {
+    generator = updateEntity(createAction, getState)
+  })
+
+  it('should call the `update` function of the entity type passing in the query object', () => {
+    expect(generator.next().value.payload)
+      .to.have.property('args')
+      .that.is.eql([{}, body, undefined])
+  })
+
+  it('should dispatch the `success` action with the server response data', () => {
+    generator.next()
+
+    const { result, entities } = normalize(body, apiTypes.USER.schema)
+
+    expect(
+      generator.next({ response: { result, entities } }).value
+    ).to.deep.equal(
+      put(
+        actions.succeedUpdate({
+          entityType,
+          requestId: deriveRequestIdFromAction(createAction),
+          value: result,
+          entities,
+        })
+      )
+    )
+  })
+
+  it('should dispatch an `error` action if the server request fails', () => {
+    generator.next()
+
+    const error = 'Some error message'
+
+    expect(generator.next({ error }).value).to.deep.equal(
+      put(actions.failUpdate({ entityType: types.USER, requestId, error }))
+    )
+  })
+
+  it('should dispatch an `error` action even if the error message is empty', () => {
+    generator.next()
+
+    const error = ''
+
+    expect(generator.next({ error }).value).to.deep.equal(
+      put(actions.failUpdate({ entityType: types.USER, requestId, error }))
+    )
+  })
+
+  it('should not create an `error` if the server returns an empty response.', () => {
+    generator.next()
+
+    const response = null
+
+    expect(generator.next({ response }).value).to.not.deep.equal(
+      put(actions.failUpdate({ entityType: types.USER, requestId }))
+    )
+  })
+
+  it('should create an empty action if the server responds with an empty result.', () => {
+    generator.next()
+
+    const response = null
+
+    expect(generator.next({ response }).value).to.deep.equal(
+      put(
+        actions.succeedUpdate({
+          entityType: types.USER,
+          requestId,
+          value: undefined,
+          entities: {},
+        })
+      )
+    )
+  })
+})


### PR DESCRIPTION
`kraken` did not correctly check whether a request had errored. Empty `statusText` messages or falsy ones would trick it into thinking there is no error. This is now more explicit. 